### PR TITLE
DR-33 Add Plywood support for Amazon Athena

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,539 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.0.tgz",
+      "integrity": "sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.3.0.tgz",
+      "integrity": "sha512-hOsgg1fxdle9Fo4aqYCHBnrMoJEwk+sjEZUtl/dwcD4a6wW3Ono9bIC0R8QEJbOQoLqQ5X+JFiQIB2+dIIokNg==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-athena": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.3.0.tgz",
+      "integrity": "sha512-KQyWE5yCyItHuNlb3/T7fcZ/Yp4BK0m1HnRZBjYB2eon1PTXBUfgHRcBytZLEekeaeigxy2G7u7rIjzQbnYMdw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.3.0",
+        "@aws-sdk/credential-provider-node": "3.3.0",
+        "@aws-sdk/fetch-http-handler": "3.3.0",
+        "@aws-sdk/hash-node": "3.3.0",
+        "@aws-sdk/invalid-dependency": "3.3.0",
+        "@aws-sdk/middleware-content-length": "3.3.0",
+        "@aws-sdk/middleware-host-header": "3.3.0",
+        "@aws-sdk/middleware-logger": "3.3.0",
+        "@aws-sdk/middleware-retry": "3.3.0",
+        "@aws-sdk/middleware-serde": "3.3.0",
+        "@aws-sdk/middleware-signing": "3.3.0",
+        "@aws-sdk/middleware-stack": "3.1.0",
+        "@aws-sdk/middleware-user-agent": "3.3.0",
+        "@aws-sdk/node-config-provider": "3.3.0",
+        "@aws-sdk/node-http-handler": "3.3.0",
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/smithy-client": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "@aws-sdk/url-parser": "3.3.0",
+        "@aws-sdk/url-parser-native": "3.3.0",
+        "@aws-sdk/util-base64-browser": "3.1.0",
+        "@aws-sdk/util-base64-node": "3.1.0",
+        "@aws-sdk/util-body-length-browser": "3.1.0",
+        "@aws-sdk/util-body-length-node": "3.1.0",
+        "@aws-sdk/util-user-agent-browser": "3.3.0",
+        "@aws-sdk/util-user-agent-node": "3.3.0",
+        "@aws-sdk/util-utf8-browser": "3.1.0",
+        "@aws-sdk/util-utf8-node": "3.1.0",
+        "tslib": "^2.0.0",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.3.0.tgz",
+      "integrity": "sha512-d/1NjyzGl8/GyeTnhxTY1ewLBdOR9qGHcWIGukYsWllnyW/G5IwPuG0uGGCKZpBkvHcGZhZZMEfHuiEqdrLm9g==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.3.0.tgz",
+      "integrity": "sha512-kyqZMlGdH/05IhuXLBUXtj5+hhRfYiHFcJLc3ts/uiwCixswVHPAYHgyWm9ajFkmWtpz6ih+0LoYryhPbYu01A==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.3.0.tgz",
+      "integrity": "sha512-Cx0YMnO/ScGQVDns006bLbqOxNURGN2Xm21bCY0l0ZUJCdJ2va1/9q1rljDyw2KvdzZNQVRQII3uUgj/Oq/K+g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.3.0.tgz",
+      "integrity": "sha512-zawNFJoasXiaV5n0H3/KNOi7mAZ7mHpG1+nBEkoWhZ31lIUM9+heGPcxKCbf/pMQjiOebUqL1OpWe4uSWxIVMw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.3.0",
+        "@aws-sdk/shared-ini-file-loader": "3.1.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.3.0.tgz",
+      "integrity": "sha512-PPBNzPq8fHk9dEQTTE4iJi6ZWtmo057Lc+I8Rlzmvz6NthK9iKiU819tfaxVBb6ZR7bLP0BuDiCi4G1lD+rQnQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.3.0",
+        "@aws-sdk/credential-provider-imds": "3.3.0",
+        "@aws-sdk/credential-provider-ini": "3.3.0",
+        "@aws-sdk/credential-provider-process": "3.3.0",
+        "@aws-sdk/property-provider": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.3.0.tgz",
+      "integrity": "sha512-7oOF1j6ydUq43P3SsasiIpbxMKCmT0C+XwggHTGiVxNtX+QZiH1vdMf8otA7puLEey0iY5wTAIEcZhC6HenojA==",
+      "requires": {
+        "@aws-sdk/credential-provider-ini": "3.3.0",
+        "@aws-sdk/property-provider": "3.3.0",
+        "@aws-sdk/shared-ini-file-loader": "3.1.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.3.0.tgz",
+      "integrity": "sha512-V1XwKOc2WzPuBwg70yEjr3P1bJPgD7yoRBdNn7cqte5LNWl3OVI5+DeLm+ztCvMsj4Y87klqhyrtQkxaxwdkGw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/querystring-builder": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "@aws-sdk/util-base64-browser": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.3.0.tgz",
+      "integrity": "sha512-sKrcmKoBqwhGmc7M0zae/YO06ueqh0uktZriQO+JpdIpG9MAiduqr9z3VR8IDhkCsznQqf6xRU5fdiaL6bcy9A==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "@aws-sdk/util-buffer-from": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.3.0.tgz",
+      "integrity": "sha512-gYPEnnMft3bT1/v4xLjvqU4Os+mVqAhg5FCQGmnk2keWuaTX3SVKDr5XEt4mg7WuP81/ldunvlgAF2RdULGn1Q==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.1.0.tgz",
+      "integrity": "sha512-wE6Am+/FKuINc/aypXiBiLAatlSyxYQ9wGGQHf2iYOX5d5bHLOVKPoRwcqSCaiaR32aRcS7R+IhgxeBy+ajsMQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.3.0.tgz",
+      "integrity": "sha512-QSNTYBs8uGEtAxG9/97Jjfw1jI9Dyk8HUILX1pwDaZ9X+a0O/cdotqHbvwE1sylAlZl+clm2TDoKeLnaOHWRhg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.3.0.tgz",
+      "integrity": "sha512-3rt5mfo0HFmKBcHQOsBLi0snVWnnbhqu0wuZmralffQLOZ7xl8p2213hwIGHt24aefjMFG+907cwoact1vEulg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.3.0.tgz",
+      "integrity": "sha512-ySRUXK2UcGto73JDxeNjne/e7NvEoUtETS+U3+euD4DDUr+Bh9LRim7XxjkPciSE3VINVxZEP2C92XLYAQHcCA==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.3.0.tgz",
+      "integrity": "sha512-62XOdoCS9+ZEUfccMkGVXHENsaMnIJ+IjQEwp6i79CVz8v387yVZRCb/cpATHILb2eLz+HsSiQvWiK3vZbTeDw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/service-error-classification": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "react-native-get-random-values": "^1.4.0",
+        "tslib": "^1.8.0",
+        "uuid": "^3.0.0"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.3.0.tgz",
+      "integrity": "sha512-BLXJSj1erTlId6rj7I8YVGfJv82mDc2n52REYiR5Bnb7ob7ZBUlt5QFfLXC3HgCGIHT8ks7Kh7liTaIGXu1MVg==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.3.0.tgz",
+      "integrity": "sha512-6SdBgzibJLtOrBI8ANIVunsO2mPj2bNmaAGutLU5AOg313uaZWVZWhRkBvmk6KryH3B74EueOgI2+M2FWd6Ruw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/signature-v4": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.1.0.tgz",
+      "integrity": "sha512-lin0C0xPspT/orPMWWHMYG/7Z128NsSj6Khs4G6TH+2rIixXxQtHLen8H2dSPNIYXnLaxvtUDl5VuqjRt+s2Ow==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.3.0.tgz",
+      "integrity": "sha512-7kH0kpjcgtaxDnR5cdCHnOtsg35fMU8dnqcciTUUNIO619P4GFUROom0IpWMTDHeee4uGDTbJJ8j+dZL06/1bA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.3.0.tgz",
+      "integrity": "sha512-5zxRyXu8oQuTOMFNPbeDsbR9Dm9XyZGAvK4WFmMm9XGfD04H9kllYVluGNo7fpV59DRsd+n8ft6g2kXm2PaMRg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.3.0",
+        "@aws-sdk/shared-ini-file-loader": "3.1.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.3.0.tgz",
+      "integrity": "sha512-24oLdrLfKPV8BtszIjxzc+SxBVrUDv7p8WmTHd9IdBWCU3BATcsJpAF6piRJ7o/VzJwvjHrk41Fum6iBNAXsLQ==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.3.0",
+        "@aws-sdk/protocol-http": "3.3.0",
+        "@aws-sdk/querystring-builder": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.3.0.tgz",
+      "integrity": "sha512-JTyjtXVNhFczL9IfgwXD55F6DqXL50PhfZxFW92t5dDj5VtWpOL74BbuxHQxHBgnQv1FKLr6N9cr7gfXWexDug==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-fAQ0iN489Sg3bHgVt1oRqPke3oEtWTPk/7LjVtx58+C5LdO4ynnERanB6YRG4NE+eeta92Ea/d+rmggfS/WQ2g==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.3.0.tgz",
+      "integrity": "sha512-2cTxRX3/p/GXNbyIPt3+Jn2TA4tI8dUpwLB5va1/W4YJ7baNoyKCZGFbGh9N3bsdl6x9MBk+wg8qemoXjNkr6g==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "@aws-sdk/util-uri-escape": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.3.0.tgz",
+      "integrity": "sha512-2tJ8Vj6mJNDrDx0tMXgE7GpwRhsrmXlUD4KI2m33BKzgB6vPl+iKappD/FSFheINpScVWP1oCV2+XgBLuZ25eQ==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.3.0.tgz",
+      "integrity": "sha512-5sVE9AhvwTrlz3vm50oaVOFFjY5WGt2TOyqcV290l6TifHbJwxd5+sDq5e9wVowCiYaKB5KiRLHIn1F2pIhDTw=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.1.0.tgz",
+      "integrity": "sha512-5MxZ/CnSaWvecwtLWmcskMe41zBnAkckQRl+xKygl8wLD/q0goWcmMkA4Sx9fyFnGQtGN/+nNvu0dlG2Arxmvw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.3.0.tgz",
+      "integrity": "sha512-l12hSwBam5Leghj4DsgJp28cDu4IFwCGSNJrNndt3CffN5RpCgayuVBnQpHtOnO01Eu728/zA3z4DKu9xXhn9Q==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.1.0",
+        "@aws-sdk/types": "3.1.0",
+        "@aws-sdk/util-hex-encoding": "3.1.0",
+        "@aws-sdk/util-uri-escape": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.3.0.tgz",
+      "integrity": "sha512-8cwSvHLlvPlQww1TnK9eu/vL7u4kWYM6C8N9mU+ug3SwvuqwIDTCYV8n6Gf+0gvu7m/J0PrIAKk32gnYPI1u6Q==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.1.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.1.0.tgz",
+      "integrity": "sha512-4Az7cemXCN4Qp8EheNkZTJJqIG0dvCT2KAreJLoclcVTcEFw2rzlATUnSeia1YTRsVd6aNxD001Ug7f3vYcQkw=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.3.0.tgz",
+      "integrity": "sha512-HkzZJHOlvpedNxt67NQMF1cbo53bvw9rAUuOaLyw6eBZKYD/qYsUwoUwCMnnpOw7AnRKx6N7oYyYR/sAkciTXw==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/url-parser-native": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.3.0.tgz",
+      "integrity": "sha512-vdAjz9NKpJkJyyFhAw0BtsZBGtWuPiorVKJver1DK5R7Ckk9zS4Wz+bY33KKqffFApyepFdu289TdMShSCOQPw==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0",
+        "url": "^0.11.0"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.1.0.tgz",
+      "integrity": "sha512-xkodj0VnkHl1gdYI9Nl4E2Ed+atM3xBTNaedoGnmqoyosMjPRJCpU8uFBmdiF4e+GGPsXlYe9oA/hLyJFxmeSQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.1.0.tgz",
+      "integrity": "sha512-FEtnINw2MeD3LAtyGcofah5D8j6OjpmwNKibr7mIgosRO++iVyXe2xa6iOoptZFn5pIU0C4fkJn5o+kjBhRafA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.1.0.tgz",
+      "integrity": "sha512-vzKDD/p1gcA05jeLmn6+6HdOY4G6Axyp6dj1R1nVeFpPPx6KkFsNGL9/CoaRT2TGv1fHBoDXsve9JRaCxrER4Q==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.1.0.tgz",
+      "integrity": "sha512-MfJoU2wFWkOmbjWDepq5bDGYZlpvtBi2Vs8ZeTcm/4+q+3L9tJ/Zb/Ofx5oeRg9VhCsAjvceQTdX+CAyP8byXA==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.1.0.tgz",
+      "integrity": "sha512-UeC4VKmWYgTXjNdLVHfurrdhznnoxWLUFx8xspyRd58BhSZ5vc5HiiKTPX/CGxzAP/qZG668PaoOJucwmEam4g==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.1.0.tgz",
+      "integrity": "sha512-MPOsUY3USCUBaqZ3ifgE9il/liVxEKsz6dYQ08pdtWRzZx2CT7kWslQeNAT565pMvktnvdLjfzBw2FwnSI6nqg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.1.0.tgz",
+      "integrity": "sha512-HAU9Sx3EJMGU4Cfq2m3t2QnkINNQx5KWa6xGctCLN2C8bNWOpKqQhWO6qcxsXalrdW5qiXY5sj8JZGRaLa3yyQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.1.0.tgz",
+      "integrity": "sha512-1ZcXVJpsA6uW3tDTQI+Rpawqh76fyHpFc55ST8VGyMgmCzlJzBpYG0ck1kqVRSUP7YyvkJQvHfcm+U6doL5Xkw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.3.0.tgz",
+      "integrity": "sha512-IXl5CStrW9gxZjENIkHHcnskeTKY1rFg0HVkNesjgdxX+Ly8RfpQ5VK1yXn84gz9mQbnDPXTyfh/NHt3uUpKfQ==",
+      "requires": {
+        "@aws-sdk/types": "3.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.3.0.tgz",
+      "integrity": "sha512-EVGCqLWu4mmtqmdorW8aKA0Kc9pbAYgIMhmXN5vH277qQJGwx2TC5yuNeufoLWdk5rIb+MdXLi1CqmtyHd7mYw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.3.0",
+        "@aws-sdk/types": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.1.0.tgz",
+      "integrity": "sha512-vJP20me+Wc1RJHq+Y+gFD25aWhbQte+Qkyh3SOKQ+YvNaMcaeVwOV7b3Y3ItBuMdutHLJWmbJ2wF6dhhpy1kOA==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.1.0.tgz",
+      "integrity": "sha512-lrBLkROMh9kTjHOguusqLvTX5+5O5CVpAGeISZlW6CCx2pMHtVRyE9cdNuRI8aJpyZsU12j8SoaKDUPGD+ixzw==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.1.0",
+        "tslib": "^1.8.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -301,6 +834,11 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
       "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -775,6 +1313,11 @@
       "requires": {
         "split": "^1.0.0"
       }
+    },
+    "fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -2160,6 +2703,19 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "react-native-get-random-values": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.5.1.tgz",
+      "integrity": "sha512-L76sTcz3jdFmc7Gn41SHOxCioYY3m4rtuWEUI6X8IeWVmkflHXrSyAObOW4eNTM5qytH+45pgMCVKJzfB/Ik4A==",
+      "requires": {
+        "fast-base64-decode": "^1.0.0"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -2936,6 +3492,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2944,8 +3516,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "tonicExampleFilename": "docs/examples/tonic.js",
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.3.0",
     "@google-cloud/bigquery": "^5.0.1",
     "chronoshift": "^0.9.4",
     "druid-query-toolkit": "^0.8.0",

--- a/rrollup
+++ b/rrollup
@@ -21,6 +21,7 @@ cat \
   build/dialect/postgresDialect.js \
   build/dialect/druidDialect.js \
   build/dialect/bigQueryDialect.js \
+  build/dialect/awsAthenaDialect.js \
   build/datatypes/common.js \
   build/datatypes/attributeInfo.js \
   build/datatypes/range.js \
@@ -106,6 +107,7 @@ cat \
   build/external/druidSqlExternal.js \
   build/external/druidExternal.js \
   build/external/bigQueryExternal.js \
+  build/external/awsAthenaExternal.js \
   build/executor/basicExecutor.js \
   extra/postfix.js \
   | grep -v '^import ' \

--- a/src/dialect/awsAthenaDialect.ts
+++ b/src/dialect/awsAthenaDialect.ts
@@ -2,56 +2,56 @@ import { Duration, Timezone } from 'chronoshift';
 import { PlyType, PlyTypeSimple } from '../types';
 import { SQLDialect } from './baseDialect';
 
-export class BigQueryDialect extends SQLDialect {
+export class AwsAthenaDialect extends SQLDialect {
   static TIME_BUCKETING: Record<string, string> = {
-    PT1S: '%Y-%m-%d %H:%M:%SZ',
-    PT1M: '%Y-%m-%d %H:%M:00Z',
+    PT1S: '%Y-%m-%d %H:%i:%SZ',
+    PT1M: '%Y-%m-%d %H:%i:00Z',
     PT1H: '%Y-%m-%d %H:00:00Z',
     P1D: '%Y-%m-%d 00:00:00Z',
     P1M: '%Y-%m-01 00:00:00Z',
     P1Y: '%Y-01-01 00:00:00Z'
   };
 
+  // Format: {fromType: {toType: 'expression'}}
   static CAST_TO_FUNCTION: Record<string, Record<string, string>> = {
     TIME: {
-      NUMBER: 'TIMESTAMP_MILLIS($$)',
+      NUMBER: 'FROM_UNIXTIME($$)',
     },
     NUMBER: {
-      TIME: 'UNIX_MILLIS($$)',
-      STRING: 'cast($$ as NUMERIC)',
+      TIME: 'cast(to_unixtime($$)*1000 as BIGINT)',
+      STRING: 'cast($$ as BIGINT)',
     },
     STRING: {
-      NUMBER: 'cast($$ as string)',
+      NUMBER: 'cast($$ as varchar)',
     },
   };
 
-  // TODO Complete the rest of functions
   static TIME_PART_TO_FUNCTION: Record<string, string> = {
     SECOND_OF_MINUTE: "extract(SECOND from $$)",
     SECOND_OF_HOUR: "(extract(MINUTE from $$)*60+extract(SECOND from $$))",
     SECOND_OF_DAY: "((extract(HOUR from $$)*60+extract(MINUTE from $$))*60+extract(SECOND from $$))",
     SECOND_OF_WEEK:
-      "(((mod((extract(DAYOFWEEK from $$)+6), 7)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$))*60 + extract(SECOND from $$))",
+      "(((mod((extract(DAY_OF_WEEK from $$)+6), 7)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$))*60 + extract(SECOND from $$))",
     SECOND_OF_MONTH:
       "((((extract(DAY from $$)-1)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$))*60+extract(SECOND from $$))",
     SECOND_OF_YEAR:
-      "((((extract(DAYOFYEAR from $$)-1)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$))*60+extract(SECOND from $$))",
+      "((((extract(DAY_OF_YEAR from $$)-1)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$))*60+extract(SECOND from $$))",
     //
     MINUTE_OF_HOUR: "extract(MINUTE from $$)",
     MINUTE_OF_DAY: "extract(HOUR from $$)*60+extract(MINUTE from $$)",
     MINUTE_OF_WEEK:
-      "(mod(extract(DAYOFWEEK from $$)+6, 7)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$)",
+      "(mod(extract(DAY_OF_WEEK from $$)+6, 7)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$)",
     MINUTE_OF_MONTH: "((extract(DAY from $$)-1)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$)",
-    MINUTE_OF_YEAR: "((extract(DAYOFYEAR from $$)-1)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$)",
+    MINUTE_OF_YEAR: "((extract(DAY_OF_YEAR from $$)-1)*24)+extract(HOUR from $$)*60+extract(MINUTE from $$)",
     //
     HOUR_OF_DAY: "extract(HOUR from $$)",
-    HOUR_OF_WEEK: "(mod((extract(DAYOFWEEK from $$) + 6), 7) * 24 + extract(HOUR from $$))",
+    HOUR_OF_WEEK: "(mod((extract(DAY_OF_WEEK from $$) + 6), 7) * 24 + extract(HOUR from $$))",
     HOUR_OF_MONTH: "((extract(DAY from $$)-1)*24+extract(HOUR from $$))",
-    HOUR_OF_YEAR: "((extract(DAYOFYEAR from $$)-1)*24+extract(HOUR from $$))",
+    HOUR_OF_YEAR: "((extract(DAY_OF_YEAR from $$)-1)*24+extract(HOUR from $$))",
     //
-    DAY_OF_WEEK: "extract(DAYOFWEEK from $$)",
+    DAY_OF_WEEK: "extract(DAY_OF_WEEK from $$)",
     DAY_OF_MONTH: "extract(DAY from $$)",
-    DAY_OF_YEAR: "extract(DAYOFYEAR from $$)",
+    DAY_OF_YEAR: "extract(DAY_OF_YEAR from $$)",
     //
     WEEK_OF_YEAR: "EXTRACT(week from $$)",
     //
@@ -59,30 +59,24 @@ export class BigQueryDialect extends SQLDialect {
     YEAR: "EXTRACT(year from $$)",
   };
 
-  public escapeName(name: string): string {
-    name = name.replace(/`/g, '``');
-    return '`' + name + '`';
-  }
-
   public constantGroupBy(): string {
     return "";
   }
 
   public castExpression(inputType: PlyType, operand: string, cast: string): string {
-    let castFunction = BigQueryDialect.CAST_TO_FUNCTION[cast][inputType];
+    let castFunction = AwsAthenaDialect.CAST_TO_FUNCTION[cast][inputType];
     if (!castFunction)
       throw new Error(`unsupported cast from ${inputType} to ${cast} in BigQuery dialect`);
     return castFunction.replace(/\$\$/g, operand);
   }
 
   public extractExpression(operand: string, regexp: string): string {
-    // https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#regexp_extract
-    return `REGEXP_EXTRACT(${operand}, '${regexp}'))`;
+    return `regexp_extract(${operand}, '${regexp}'))`;
   }
 
   public indexOfExpression(str: string, substr: string): string {
-    // https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#strpos
-    return `STRPOS(${substr}, ${str}) - 1`;
+    // todo: need quotes?
+    return `STRPOS(${str}, ${substr}) - 1`;
   }
 
   public timeBucketExpression(operand: string, duration: Duration, timezone: Timezone): string {
@@ -90,28 +84,27 @@ export class BigQueryDialect extends SQLDialect {
   }
 
   public timeFloorExpression(operand: string, duration: Duration, timezone: Timezone): string {
-    let bucketFormat = BigQueryDialect.TIME_BUCKETING[duration.toString()];
+    let bucketFormat = AwsAthenaDialect.TIME_BUCKETING[duration.toString()];
     if (!bucketFormat) throw new Error(`unsupported duration '${duration}'`);
     return this.walltimeToUTC(
-      `FORMAT_DATETIME('${bucketFormat}', CAST(${this.utcToWalltime(operand, timezone)} AS DATETIME))`,
+      `FORMAT_DATETIME(${this.utcToWalltime(operand, timezone)}, '${bucketFormat}')`,
       timezone,
     );
   }
 
   public timePartExpression(operand: string, part: string, timezone: Timezone): string {
-    // https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#extract
-    let timePartFunction = BigQueryDialect.TIME_PART_TO_FUNCTION[part];
+    let timePartFunction = AwsAthenaDialect.TIME_PART_TO_FUNCTION[part];
     if (!timePartFunction) throw new Error(`unsupported part ${part} in BigQuery dialect`);
     return timePartFunction.replace(/\$\$/g, this.utcToWalltime(operand, timezone));
   }
 
   public regexpExpression(expression: string, regexp: string): string {
-    // https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#regexp_contains
-    return `REGEXP_CONTAINS(${expression}, ${this.escapeLiteral(regexp)})`;
+    // https://prestodb.io/docs/0.217/functions/regexp.html
+    return `regexp_like(${expression}, ${this.escapeLiteral(regexp)})`;
   }
 
-  public containsExpression(str: string, substr: string): string {
-    return `STRPOS(${str},${substr})>0`;
+  public containsExpression(a: string, b: string): string {
+    return `STRPOS(${a},${b})>0`;
   }
 
 
@@ -129,43 +122,37 @@ export class BigQueryDialect extends SQLDialect {
   timeShiftExpression(operand: string, duration: Duration, step: int, timezone: Timezone): string {
     if (step === 0) return operand;
 
-    // https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime_add
-    let sqlFn = step > 0 ? 'DATETIME_ADD(' : 'DATETIME_SUB(';
+    let mult = step < 0 ? '-1 * ' : '';
     let spans = duration.multiply(Math.abs(step)).valueOf();
     if (spans.week) {
-      operand = sqlFn + operand + ', INTERVAL ' + String(spans.week) + ' WEEK)';
+      operand = `DATE_ADD('week', ${mult}${spans.week}, ${operand})`;
     }
     if (spans.month) {
-      let expr = String(spans.month);
-      operand = sqlFn + operand + ", INTERVAL " + expr + " MONTH)";
+      operand = `DATE_ADD('MONTH', ${mult}${spans.month}, ${operand})`;
     }
     if (spans.year) {
-      let expr = String(spans.year);
-      operand = sqlFn + operand + ", INTERVAL " + expr + " YEAR)";
+      operand = `DATE_ADD('YEAR', ${mult}${spans.year}, ${operand})`;
     }
     if (spans.day) {
-      let expr = String(spans.day);
-      operand = sqlFn + operand + ", INTERVAL " + expr + " DAY)";
+      operand = `DATE_ADD('DAY', ${mult}${spans.day}, ${operand})`;
     }
     if (spans.hour) {
-      let expr = String(spans.hour);
-      operand = sqlFn + operand + ", INTERVAL " + expr + " HOUR)";
+      operand = `DATE_ADD('hour', ${mult}${spans.hour}, ${operand})`;
     }
     if (spans.minute) {
-      let expr = String(spans.minute);
-      operand = sqlFn + operand + ", INTERVAL " + expr + " MINUTE)";
+      operand = `DATE_ADD('MINUTE', ${mult}${spans.minute}, ${operand})`;
     }
     if (spans.second) {
-      let expr = spans.second;
-      operand = sqlFn + operand + ", INTERVAL " + expr + " SECOND)";
+      operand = `DATE_ADD('second', ${mult}${spans.second}, ${operand})`;
     }
     return operand;
   }
 
   timeToSQL(date: Date): string {
-    // format: '2020-11-17 15:11:12.086418 UTC'
+    // format: '"2021-01-26T04:59:59.245Z"'
+    // see https://prestodb.io/docs/0.217/functions/datetime.html
     if (!date) return this.nullConstant();
-    return `TIMESTAMP('${date.toISOString()}')`;
+    return `from_iso8601_timestamp('${date.toISOString()}')`;
   }
 
   public utcToWalltime(operand: string, timezone: Timezone): string {

--- a/src/dialect/mySqlDialect.ts
+++ b/src/dialect/mySqlDialect.ts
@@ -176,4 +176,9 @@ export class MySQLDialect extends SQLDialect {
   public indexOfExpression(str: string, substr: string): string {
     return `LOCATE(${substr}, ${str}) - 1`;
   }
+
+
+  constantGroupBy(): string {
+    return "";
+  }
 }

--- a/src/dialect/postgresDialect.ts
+++ b/src/dialect/postgresDialect.ts
@@ -82,7 +82,7 @@ export class PostgresDialect extends SQLDialect {
   }
 
   public constantGroupBy(): string {
-    return "GROUP BY ''=''";
+    return "";
   }
 
   public timeToSQL(date: Date): string {

--- a/src/external/awsAthenaExternal.ts
+++ b/src/external/awsAthenaExternal.ts
@@ -1,0 +1,27 @@
+import { PlywoodRequester } from 'plywood-base-api';
+import { Attributes } from '../datatypes';
+import { AwsAthenaDialect } from '../dialect/awsAthenaDialect';
+import { External, ExternalJS, ExternalValue } from './baseExternal';
+import { SQLExternal } from './sqlExternal';
+
+export class AwsAthenaExternal extends SQLExternal {
+  static engine = 'athena';
+  static type = 'DATASET';
+
+
+  static fromJS(parameters: ExternalJS, requester: PlywoodRequester<any>): AwsAthenaExternal {
+    let value: ExternalValue = External.jsToValue(parameters, requester);
+    return new AwsAthenaExternal(value);
+  }
+
+  constructor(parameters: ExternalValue) {
+    super(parameters, new AwsAthenaDialect());
+    this._ensureEngine('athena');
+  }
+
+  protected getIntrospectAttributes(): Promise<Attributes> {
+    throw 'Introspection is done in redash';
+  }
+}
+
+External.register(AwsAthenaExternal);

--- a/src/external/awsAthenaExternal.ts
+++ b/src/external/awsAthenaExternal.ts
@@ -1,9 +1,16 @@
 import { PlywoodRequester } from 'plywood-base-api';
-import { Attributes } from '../datatypes';
+import { AttributeInfo, Attributes } from '../datatypes';
 import { AwsAthenaDialect } from '../dialect/awsAthenaDialect';
+import { PlyType } from '../types';
 import { External, ExternalJS, ExternalValue } from './baseExternal';
 import { SQLExternal } from './sqlExternal';
 
+export interface AthenaColumn {
+  name: string;
+  type: string;
+}
+
+// NB: Athena is a copy of Presto, sql syntax is the same
 export class AwsAthenaExternal extends SQLExternal {
   static engine = 'athena';
   static type = 'DATASET';
@@ -14,13 +21,48 @@ export class AwsAthenaExternal extends SQLExternal {
     return new AwsAthenaExternal(value);
   }
 
+  // https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+  private static NUMBER_TYPES = ['tinyint', 'smallint', 'int', 'integer', 'bigint', 'float', 'decimal'];
+  private static STRING_TYPES = ['char', 'varchar', 'string'];
+  private static DATE_TYPES = ['date', 'timestamp'];
+  // there's also map,array and struct types, leaving out for simplicity :)
+
+  // Method for converting Athena/Presto column info to plywood data types
+  // This will be used in plywood-server
+  static mapTypes(columns: AthenaColumn[]): Attributes {
+    return columns
+      .map((column: AthenaColumn) => {
+        let name = column.name;
+        let type: PlyType;
+        let nativeType = column.type.toLowerCase();
+        if (AwsAthenaExternal.DATE_TYPES.indexOf(nativeType) > -1) {
+          type = 'TIME';
+        } else if (AwsAthenaExternal.STRING_TYPES.indexOf(nativeType) > -1) {
+          type = 'STRING';
+        } else if (AwsAthenaExternal.NUMBER_TYPES.indexOf(nativeType) > -1) {
+          type = 'NUMBER';
+        } else if (nativeType === 'BOOLEAN') {
+          type = 'BOOLEAN';
+        } else {
+          return null;
+        }
+
+        return new AttributeInfo({
+          name,
+          type,
+          nativeType
+        });
+      });
+  }
+
   constructor(parameters: ExternalValue) {
     super(parameters, new AwsAthenaDialect());
     this._ensureEngine('athena');
   }
 
   protected getIntrospectAttributes(): Promise<Attributes> {
-    throw 'Introspection is done in redash';
+    // NB: Redash does all of the introspection, we just need to provide mapping function for plywood-server
+    return Promise.resolve([]);
   }
 }
 

--- a/src/external/bigQueryExternal.ts
+++ b/src/external/bigQueryExternal.ts
@@ -58,6 +58,7 @@ export class BigQueryExternal extends SQLExternal {
   }
 
   protected getIntrospectAttributes(): Promise<Attributes> {
+    // NB: introspection is done in redash
     return toArray(
       this.requester({
         query: `select column_name as name, data_type as type

--- a/test/simulate/simulateMySQL.mocha.js
+++ b/test/simulate/simulateMySQL.mocha.js
@@ -95,7 +95,7 @@ describe('simulate MySQL', () => {
       SUM(CASE WHEN (\`cut\`<=>"good") THEN \`price\` ELSE 0 END) AS \`PriceGoodCut\`
       FROM \`diamonds\` AS t
       WHERE (\`color\`<=>"D")
-      GROUP BY ''
+
     `,
     ]);
 
@@ -158,7 +158,7 @@ describe('simulate MySQL', () => {
       SELECT
       COUNT(*) AS \`__VALUE__\`
       FROM \`diamonds\` AS t
-      GROUP BY ''
+
     `,
     ]);
 
@@ -278,7 +278,7 @@ describe('simulate MySQL', () => {
       SUM(\`price\`) AS \`__VALUE__\`
       FROM \`diamonds\` AS t
       WHERE (\`color\`<=>"D")
-      GROUP BY ''
+
     `,
     ]);
   });


### PR DESCRIPTION
* awsAthenaDialect.ts - athena dialect
* bigQueryDialect.ts - fixed strpos
* mySqlDialect.ts, postgresDialect.ts - removed constant group by, this code was never run :D
* package.json - added athena client
* rrollup - added athena files to build concat script

Question to @Romucmad and @Isabek: as @Isabek told me, the schema introspection is implemented in redash, but I saw your [recent commit](https://github.com/dataminelab/plywood/commit/2e16e3c1afb69e640118564d2bdcfba3aef2be5f)  changing the code that does introspection for postgresql. I wonder what's the best way to approach it nowadays